### PR TITLE
update company name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 NTT Communications Corp.
+Copyright (c) 2024 NTT DOCOMO BUSINESS, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Android Chrome、Mobile Safari(iOS,iPadOS)でも利用可能ですが、画面UI
 ## 📜 License / Copyright
 
 [MIT License](./LICENSE)  
-Copyright (c) 2024- NTT Communications Corp.
+Copyright (c) 2024- NTT DOCOMO BUSINESS, Inc.
 
 ソフトウェアの一部に [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) のソフトウェアが含まれています。
 

--- a/THIRD_PARTY_LICENSE
+++ b/THIRD_PARTY_LICENSE
@@ -939,7 +939,7 @@ The following software may be included in this product: @skyway-sdk/analytics-cl
 
 MIT License
 
-Copyright (c) 2024 NTT Communications Corporation
+Copyright (c) 2024 NTT DOCOMO BUSINESS, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -965,7 +965,7 @@ The following software may be included in this product: @skyway-sdk/common, @sky
 
 MIT License
 
-Copyright (c) 2023 NTT Communications Corporation
+Copyright (c) 2023 NTT DOCOMO BUSINESS, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "webpack --mode=production",
     "lint": "eslint --ext .ts,.tsx . && tsc --project . --noEmit"
   },
-  "author": "NTT Communications Corp.",
+  "author": "NTT DOCOMO BUSINESS, Inc.",
   "license": "MIT",
   "devDependencies": {
     "@emotion/babel-preset-css-prop": "^11.12.0",


### PR DESCRIPTION
This pull request updates copyright and author information across multiple files to reflect a change in the organization name from "NTT Communications Corp." to "NTT DOCOMO BUSINESS, Inc."

### Updates to Organization Name:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated copyright notice to reflect the new organization name.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L140-R140): Changed the copyright section to use "NTT DOCOMO BUSINESS, Inc." instead of "NTT Communications Corp."
* [`THIRD_PARTY_LICENSE`](diffhunk://#diff-c4a5ba2529dca98a1d4b81db6237a8036a6990be61c3bd1eab8d8bad2198f9e7L942-R942): Updated copyright information for included software licenses to reflect the new organization name for both 2024 and 2023 entries. [[1]](diffhunk://#diff-c4a5ba2529dca98a1d4b81db6237a8036a6990be61c3bd1eab8d8bad2198f9e7L942-R942) [[2]](diffhunk://#diff-c4a5ba2529dca98a1d4b81db6237a8036a6990be61c3bd1eab8d8bad2198f9e7L968-R968)
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R10): Changed the `author` field to "NTT DOCOMO BUSINESS, Inc." to match the updated organization name.

---

### reference: Press Releases

- https://www.ntt.com/about-us/press-releases/news/article/2025/0509_3.html
- https://www.ntt.com/en/about-us/press-releases/news/article/2025/0509_3.html
