### PR TITLE
update @skyway-sdk/room to version 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
         "@emotion/react": "^11.14.0",
-        "@skyway-sdk/room": "^1.15.2",
+        "@skyway-sdk/room": "^2.0.0",
         "bowser": "^2.12.1",
         "debug": "^4.4.3",
         "dotenv-flow": "^4.1.0",
@@ -1144,9 +1144,9 @@
       }
     },
     "node_modules/@skyway-sdk/analytics-client": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/analytics-client/-/analytics-client-1.1.1.tgz",
-      "integrity": "sha512-kwoI1BebCM5b+09pLODjqO2jyBc2QKu8fcuLdzhQkla7ySBnDJGEVNxVMua0gzza4aH2Wn0bnGZU26zO0AQG2w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/analytics-client/-/analytics-client-2.0.0.tgz",
+      "integrity": "sha512-AATfH8dOhX5pcKPaYZfq/fmkjkWnK7l2QCVnXfFJRDyAymqu1iZx6deh/qMNjiNAM5BcOoxEkRljA1Mt4ATO1w==",
       "license": "MIT",
       "dependencies": {
         "isomorphic-ws": "^4.0.1",
@@ -1155,25 +1155,25 @@
       }
     },
     "node_modules/@skyway-sdk/common": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/common/-/common-1.5.0.tgz",
-      "integrity": "sha512-oYHtWcBLVh098UkldKU87wZf6sdPqO+3ge+glpJMyVs2ZIuQF4b5uz50F/Lugv3G1Sc8UHNo5h5Vs9w6J4uQaQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/common/-/common-2.0.0.tgz",
+      "integrity": "sha512-VFBcpSN7uYAou/16fVbKxiVbZHyIMvHGH819LqxwOd00HOkOBF3ZndTrGWe+7fDSmYalwwhTT2XALAh98r4v7g==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7"
       }
     },
     "node_modules/@skyway-sdk/core": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/core/-/core-1.15.2.tgz",
-      "integrity": "sha512-outcQBvbt8rJJF8xPSTao5Cz/qdioA0ncWeZXMsp4AyOKsu68b9TvFIZ7wR5oencPwRVJdL1uj46fTO0jU4h0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-HHh76ctDwXgdUNtZIK4mFoyLjdDF28JnVdvPWRiU0B6xiIoB3Ge+h4Tw2PaCoiDmTIyy8PXRaA+4v/aiUXEzxA==",
       "license": "MIT",
       "dependencies": {
-        "@skyway-sdk/analytics-client": "1.1.1",
-        "@skyway-sdk/common": "1.5.0",
-        "@skyway-sdk/rtc-api-client": "1.8.4",
-        "@skyway-sdk/signaling-client": "1.0.9",
-        "@skyway-sdk/token": "1.7.4",
+        "@skyway-sdk/analytics-client": "2.0.0",
+        "@skyway-sdk/common": "2.0.0",
+        "@skyway-sdk/rtc-api-client": "2.0.0",
+        "@skyway-sdk/signaling-client": "2.0.0",
+        "@skyway-sdk/token": "2.0.0",
         "bowser": "^2.11.0",
         "deepmerge": "^4.3.1",
         "lodash": "4.17.21",
@@ -1182,110 +1182,77 @@
         "uuid": "^9.0.0"
       }
     },
-    "node_modules/@skyway-sdk/mediasoup-client": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/mediasoup-client/-/mediasoup-client-3.15.2.tgz",
-      "integrity": "sha512-0nNB6OPSU3aTKaoElJ0jI76gLYzkO96n8oExs94hd+b2bCBIpKznvzRxlmdZQH8T4fzLfeIU7AK3WROGr+iMQA==",
-      "license": "ISC",
-      "dependencies": {
-        "@types/debug": "^4.1.12",
-        "@types/events-alias": "npm:@types/events@^3.0.3",
-        "awaitqueue": "^3.2.4",
-        "debug": "^4.4.1",
-        "events-alias": "npm:events@^3.3.0",
-        "fake-mediastreamtrack": "^2.1.2",
-        "h264-profile-level-id": "^2.2.3",
-        "sdp-transform": "^2.15.0",
-        "supports-color": "^10.1.0",
-        "ua-parser-js": "^1.0.40"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@skyway-sdk/mediasoup-client/node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/@skyway-sdk/model": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/model/-/model-1.0.3.tgz",
-      "integrity": "sha512-1sFnOY9phuO+v6f9HVeMCSRxHSkPRi2JdQVwUhqW0ArGwmBqUK+jIfU7qXGbRiuE0vxosBu+gDlMK0pw40ehSQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/model/-/model-2.0.0.tgz",
+      "integrity": "sha512-Ddhffe4Gq5+CL4UlnmI5+0YVcfQuGMh8v5wk8G/ai88WJfCUw5Uw2IgnSnf8YBaLLMoqKGe1nRntX3Gj20b39g==",
       "license": "MIT"
     },
     "node_modules/@skyway-sdk/room": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/room/-/room-1.15.2.tgz",
-      "integrity": "sha512-u1RKzQr46NLkS4FxWauw+W8XO2nXxBPTQ7jdtxGqN5vHVh3uNcC0y3TJiHFVW44H7LVC+rr8cl4lzgvdez17EQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/room/-/room-2.0.0.tgz",
+      "integrity": "sha512-51YOP3FueQTZb/zIly+HaqF57Oi1BqWfOZpL72Zn4HYIg4gjwCaNYiqWJn/fV8+i7+0DF+WKl7HvculXAPYIjA==",
       "license": "MIT",
       "dependencies": {
-        "@skyway-sdk/common": "1.5.0",
-        "@skyway-sdk/core": "1.15.2",
-        "@skyway-sdk/sfu-bot": "1.14.3",
-        "@skyway-sdk/token": "1.7.4",
+        "@skyway-sdk/common": "2.0.0",
+        "@skyway-sdk/core": "2.0.0",
+        "@skyway-sdk/sfu-bot": "2.0.0",
+        "@skyway-sdk/token": "2.0.0",
         "uuid": "^9.0.0"
       }
     },
     "node_modules/@skyway-sdk/rtc-api-client": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/rtc-api-client/-/rtc-api-client-1.8.4.tgz",
-      "integrity": "sha512-TMdpUvE7L9AAAVQV1mzl3Jp+NDF/rSnqGIghnk0G0G7R0YTXN3xRXywOecdUHVYmZiM17djtn9LhpDe1wWAyrA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/rtc-api-client/-/rtc-api-client-2.0.0.tgz",
+      "integrity": "sha512-QEilrWWf9Qm/LPToq2Pc0gdfDVdqAHiJkUw+hVbQf40SavmIM+FDWO1doxh5X7Qv1d8naqi9RQIdja7Pn5CAFg==",
       "license": "MIT",
       "dependencies": {
-        "@skyway-sdk/common": "1.5.0",
-        "@skyway-sdk/rtc-rpc-api-client": "1.8.3",
-        "@skyway-sdk/token": "1.7.4",
+        "@skyway-sdk/common": "2.0.0",
+        "@skyway-sdk/rtc-rpc-api-client": "2.0.0",
+        "@skyway-sdk/token": "2.0.0",
         "deepmerge": "^4.3.1",
         "uuid": "^9.0.0"
       }
     },
     "node_modules/@skyway-sdk/rtc-rpc-api-client": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/rtc-rpc-api-client/-/rtc-rpc-api-client-1.8.3.tgz",
-      "integrity": "sha512-LdZGk1G8YK8BzEicl+nPUdGStULXxTRQF2s3VUPYrxRKJuWePLOAbnpO5bwvkEwQLpu5o8PNVyOA7N05/0O2gQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/rtc-rpc-api-client/-/rtc-rpc-api-client-2.0.0.tgz",
+      "integrity": "sha512-9qoUEZERFm+5E7Xb2siGBoUy2jD0FdxJRLMA7XttmiRkrQNLW47zPRFOtFfaeYg7GQmXzsmS+XGBCk68TP+teQ==",
       "license": "MIT",
       "dependencies": {
-        "@skyway-sdk/common": "1.5.0",
-        "@skyway-sdk/model": "1.0.3",
+        "@skyway-sdk/common": "2.0.0",
+        "@skyway-sdk/model": "2.0.0",
         "isomorphic-ws": "^4.0.1",
         "uuid": "^9.0.0"
       }
     },
     "node_modules/@skyway-sdk/sfu-api-client": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/sfu-api-client/-/sfu-api-client-1.5.4.tgz",
-      "integrity": "sha512-o1wRIBu+GvSXKA7HOT2GVGPW6G6AALy0wvNEqG/Atb/cyibFwp7pAzmh7aYC6LZMKiJtobm/6nVx/Pt6JfZ0/A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/sfu-api-client/-/sfu-api-client-2.0.0.tgz",
+      "integrity": "sha512-Zlk2sofU+swsGBKK9E8zPf34pf7j0QBHqo8wFFFQg2ooVVzr8W6PbE0JRVva4dna+O4V+fPlxl352uWVAccE7Q==",
       "license": "MIT",
       "dependencies": {
-        "@skyway-sdk/common": "1.5.0",
-        "@skyway-sdk/mediasoup-client": "^3.15.2"
+        "@skyway-sdk/common": "2.0.0",
+        "mediasoup-client": "^3.16.5"
       }
     },
     "node_modules/@skyway-sdk/sfu-bot": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/sfu-bot/-/sfu-bot-1.14.3.tgz",
-      "integrity": "sha512-YJby+s7jNig7RAR+reCV2RGWnZVoHfKyGXLgjvZyqTzX8jya5j/nRMo8n1bT9BkzbACwMgpx1NSDvt5xqDkb+w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/sfu-bot/-/sfu-bot-2.0.0.tgz",
+      "integrity": "sha512-5lC4yYtQ8UL7oH4nQ0N3mD9qBZQblH4bsEDjRuNKSK9zuRJwMBFA05vfN1JbsKqVtFqCmBfEflSz82P5pvzOhA==",
       "license": "MIT",
       "dependencies": {
-        "@skyway-sdk/common": "1.5.0",
-        "@skyway-sdk/core": "1.15.2",
-        "@skyway-sdk/mediasoup-client": "^3.15.2",
-        "@skyway-sdk/sfu-api-client": "1.5.4",
-        "lodash": "4.17.21"
+        "@skyway-sdk/common": "2.0.0",
+        "@skyway-sdk/core": "2.0.0",
+        "@skyway-sdk/sfu-api-client": "2.0.0",
+        "lodash": "4.17.21",
+        "mediasoup-client": "^3.16.5"
       }
     },
     "node_modules/@skyway-sdk/signaling-client": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/signaling-client/-/signaling-client-1.0.9.tgz",
-      "integrity": "sha512-8MZRgXOtsP9qDLthgPf6ugL2cAQLf3eWi3DIKy6dVFmWt+RtHQmRMtf2RdFK+t8XhSnOPeL+zqlnoISFG+FWTw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/signaling-client/-/signaling-client-2.0.0.tgz",
+      "integrity": "sha512-jh6+sldw/5BvmMYA5Mj+vn9fYRib8ijCB9iJs0bJHPG3W6sFsOrcoEsU4ZPzIkizyGj72/AdPR0KBq7501wUUA==",
       "license": "MIT",
       "dependencies": {
         "isomorphic-fetch": "^3.0.0",
@@ -1295,12 +1262,12 @@
       }
     },
     "node_modules/@skyway-sdk/token": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/token/-/token-1.7.4.tgz",
-      "integrity": "sha512-hFExP7hmtPsitKUg8Lm+PRlEeNKO6/XiM1jtFQIZkjH+UWBHr98mwIG1CanvMdI31IpUWej+V6zYPRrpRnEbYA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/token/-/token-2.0.0.tgz",
+      "integrity": "sha512-I/O+utGqLFtuwRaCOeGGcXtGUvOCjZWlGlt8NZls+aEyRznI+VCnYmxV8hGFcWI6nyoqEH+7/A3g1mBDaenR2Q==",
       "license": "MIT",
       "dependencies": {
-        "@skyway-sdk/common": "1.5.0",
+        "@skyway-sdk/common": "2.0.0",
         "jsrsasign": "^11.1.0",
         "jwt-decode": "3.1.2",
         "uuid": "^9.0.0",
@@ -5845,6 +5812,42 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mediasoup-client": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/mediasoup-client/-/mediasoup-client-3.17.1.tgz",
+      "integrity": "sha512-PDmYBjmordQcb9Kall3RZ/KYCGxeRjbypPLthadK7quKJtRi1GJA/kqjs8UMCUvmYqJyKZmnJipRYRkm9ksmcA==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/debug": "^4.1.12",
+        "@types/events-alias": "npm:@types/events@^3.0.3",
+        "awaitqueue": "^3.3.0",
+        "debug": "^4.4.3",
+        "events-alias": "npm:events@^3.3.0",
+        "fake-mediastreamtrack": "^2.2.1",
+        "h264-profile-level-id": "^2.3.1",
+        "sdp-transform": "^2.15.0",
+        "supports-color": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mediasoup"
+      }
+    },
+    "node_modules/mediasoup-client/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/memfs": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
     "@emotion/react": "^11.14.0",
-    "@skyway-sdk/room": "^1.15.2",
+    "@skyway-sdk/room": "^2.0.0",
     "bowser": "^2.12.1",
     "debug": "^4.4.3",
     "dotenv-flow": "^4.1.0",

--- a/src/conference/effects/room.ts
+++ b/src/conference/effects/room.ts
@@ -7,8 +7,6 @@ import {
   LocalAudioStream,
   LocalVideoStream,
   LocalRoomMember,
-  LocalP2PRoomMember,
-  LocalSFURoomMember,
   RoomPublication,
 } from "@skyway-sdk/room";
 
@@ -301,7 +299,7 @@ export const joinRoom = async (store: RootStore) => {
 };
 
 const publishAudio = (
-  localRoomMember: LocalP2PRoomMember | LocalSFURoomMember,
+  localRoomMember: LocalRoomMember,
   track: MediaStreamTrack,
 ) => {
   log(`publishAudio(${localRoomMember.id}, ${track.id})`);
@@ -311,7 +309,7 @@ const publishAudio = (
 };
 
 const publishVideo = (
-  localRoomMember: LocalP2PRoomMember | LocalSFURoomMember,
+  localRoomMember: LocalRoomMember,
   track: MediaStreamTrack,
 ) => {
   log(`publishVideo(${localRoomMember.id}, ${track.id})`);

--- a/src/conference/effects/room.ts
+++ b/src/conference/effects/room.ts
@@ -189,7 +189,7 @@ export const joinRoom = async (store: RootStore) => {
     if (publication.publisher.id === localRoomMember.id) return;
 
     log("onStreamPublished", publication);
-    subscribe(localRoomMember, publication, showError);
+    subscribe(localRoomMember, publication, room.mode, showError);
   });
 
   // Subscribed時の対応
@@ -294,7 +294,7 @@ export const joinRoom = async (store: RootStore) => {
     if (publication.publisher.id === localRoomMember.id) return;
 
     log("subscribe published remote stream", publication);
-    subscribe(localRoomMember, publication, showError);
+    subscribe(localRoomMember, publication, room.mode, showError);
   });
 };
 
@@ -339,6 +339,7 @@ const publishVideo = (
 const subscribe = (
   localRoomMember: LocalRoomMember,
   publication: RoomPublication,
+  mode: RoomInit["mode"] | null,
   showError: (errorMessage: string) => void,
 ) => {
   log(`subscribe(${localRoomMember.id}, ${publication.id})`);
@@ -346,7 +347,7 @@ const subscribe = (
   localRoomMember
     .subscribe(
       publication,
-      publication.contentType === "video" && localRoomMember.roomType === "sfu"
+      publication.contentType === "video" && mode === "SFU"
         ? { preferredEncodingId: "high" }
         : undefined,
     )

--- a/src/conference/stores/room.ts
+++ b/src/conference/stores/room.ts
@@ -4,14 +4,13 @@ import {
   Room,
   RemoteAudioStream,
   RemoteVideoStream,
-  LocalP2PRoomMember,
-  LocalSFURoomMember,
+  LocalRoomMember,
   WebRTCStats,
 } from "@skyway-sdk/room";
 
 class RoomStore {
   memberName: string | null;
-  member: LocalP2PRoomMember | LocalSFURoomMember | null;
+  member: LocalRoomMember | null;
   isReady: boolean;
   room: Room | null;
   mode: RoomInit["mode"] | null;
@@ -90,7 +89,7 @@ class RoomStore {
     this.isReady = true;
   }
 
-  loadMember(member: LocalP2PRoomMember | LocalSFURoomMember) {
+  loadMember(member: LocalRoomMember) {
     this.member = member;
   }
 

--- a/src/conference/stores/room.ts
+++ b/src/conference/stores/room.ts
@@ -1,8 +1,7 @@
 import { makeObservable, observable, computed, action } from "mobx";
 import { RoomInit, RoomStat } from "../utils/types";
 import {
-  P2PRoom,
-  SFURoom,
+  Room,
   RemoteAudioStream,
   RemoteVideoStream,
   LocalP2PRoomMember,
@@ -14,7 +13,7 @@ class RoomStore {
   memberName: string | null;
   member: LocalP2PRoomMember | LocalSFURoomMember | null;
   isReady: boolean;
-  room: P2PRoom | SFURoom | null;
+  room: Room | null;
   mode: RoomInit["mode"] | null;
   id: RoomInit["id"] | null;
   useH264: RoomInit["useH264"];
@@ -82,11 +81,7 @@ class RoomStore {
     return this.streams.get(this.pinnedMemberId) || null;
   }
 
-  load(
-    { mode, id, useH264 }: RoomInit,
-    skywayRoom: P2PRoom | SFURoom,
-    memberName: string,
-  ) {
+  load({ mode, id, useH264 }: RoomInit, skywayRoom: Room, memberName: string) {
     this.mode = mode;
     this.id = id;
     this.useH264 = useH264;

--- a/src/conference/stores/room.ts
+++ b/src/conference/stores/room.ts
@@ -2,7 +2,7 @@ import { makeObservable, observable, computed, action } from "mobx";
 import { RoomInit, RoomStat } from "../utils/types";
 import {
   P2PRoom,
-  SfuRoom,
+  SFURoom,
   RemoteAudioStream,
   RemoteVideoStream,
   LocalP2PRoomMember,
@@ -14,7 +14,7 @@ class RoomStore {
   memberName: string | null;
   member: LocalP2PRoomMember | LocalSFURoomMember | null;
   isReady: boolean;
-  room: P2PRoom | SfuRoom | null;
+  room: P2PRoom | SFURoom | null;
   mode: RoomInit["mode"] | null;
   id: RoomInit["id"] | null;
   useH264: RoomInit["useH264"];
@@ -84,7 +84,7 @@ class RoomStore {
 
   load(
     { mode, id, useH264 }: RoomInit,
-    skywayRoom: P2PRoom | SfuRoom,
+    skywayRoom: P2PRoom | SFURoom,
     memberName: string,
   ) {
     this.mode = mode;

--- a/src/conference/utils/skyway.ts
+++ b/src/conference/utils/skyway.ts
@@ -1,7 +1,6 @@
 import {
   Room,
-  LocalP2PRoomMember,
-  LocalSFURoomMember,
+  LocalRoomMember,
   SkyWayContext,
   SkyWayRoom,
   uuidV4,
@@ -60,7 +59,7 @@ export const initRtcRoom = async (
 export const joinRtcRoom = async (
   room: Room,
   memberName: string,
-): Promise<LocalP2PRoomMember | LocalSFURoomMember | null> => {
+): Promise<LocalRoomMember | null> => {
   return room.join({ name: memberName });
 };
 

--- a/src/conference/utils/skyway.ts
+++ b/src/conference/utils/skyway.ts
@@ -1,7 +1,5 @@
 import {
-  RoomType,
-  P2PRoom,
-  SFURoom,
+  Room,
   LocalP2PRoomMember,
   LocalSFURoomMember,
   SkyWayContext,
@@ -52,17 +50,15 @@ export const initRtcRoom = async (
   context: SkyWayContext,
   _roomType: string,
   roomName: string,
-): Promise<P2PRoom | SFURoom | null> => {
-  const roomType: RoomType = _roomType === "SFU" ? "sfu" : "p2p";
-
+): Promise<Room | null> => {
   return SkyWayRoom.FindOrCreate(context, {
-    type: roomType,
+    type: "default",
     name: roomName,
   });
 };
 
 export const joinRtcRoom = async (
-  room: P2PRoom | SFURoom,
+  room: Room,
   memberName: string,
 ): Promise<LocalP2PRoomMember | LocalSFURoomMember | null> => {
   return room.join({ name: memberName });

--- a/src/conference/utils/skyway.ts
+++ b/src/conference/utils/skyway.ts
@@ -91,12 +91,11 @@ function createConfigOption(logLevel: LogLevel) {
     rtcConfig: {
       turnPolicy: "enable",
       turnProtocol: "all",
-      encodedInsertableStreams: false,
       timeout: 30000,
       iceDisconnectBufferTimeout: 5000,
     },
     token: {
-      updateReminderSec: 30,
+      updateRemindSec: 30,
     },
     member: {
       keepaliveIntervalSec: 30,

--- a/src/conference/utils/skyway.ts
+++ b/src/conference/utils/skyway.ts
@@ -1,7 +1,7 @@
 import {
   RoomType,
   P2PRoom,
-  SfuRoom,
+  SFURoom,
   LocalP2PRoomMember,
   LocalSFURoomMember,
   SkyWayContext,
@@ -52,7 +52,7 @@ export const initRtcRoom = async (
   context: SkyWayContext,
   _roomType: string,
   roomName: string,
-): Promise<P2PRoom | SfuRoom | null> => {
+): Promise<P2PRoom | SFURoom | null> => {
   const roomType: RoomType = _roomType === "SFU" ? "sfu" : "p2p";
 
   return SkyWayRoom.FindOrCreate(context, {
@@ -62,7 +62,7 @@ export const initRtcRoom = async (
 };
 
 export const joinRtcRoom = async (
-  room: P2PRoom | SfuRoom,
+  room: P2PRoom | SFURoom,
   memberName: string,
 ): Promise<LocalP2PRoomMember | LocalSFURoomMember | null> => {
   return room.join({ name: memberName });


### PR DESCRIPTION
This pull request upgrades the SkyWay SDK from version 1.x to 2.x and refactors the codebase to use the new unified `Room` and `LocalRoomMember` types introduced in the SDK. The changes also update the room initialization and media publishing logic to match the new API, simplifying the handling of room modes and stream encoding options.

**SDK Upgrade and API Refactor:**

* Upgraded `@skyway-sdk/room` dependency from `^1.15.2` to `^2.0.0` in `package.json`, enabling use of the new SDK features and types.
* Refactored all room and member types to use the new unified `Room` and `LocalRoomMember` types, replacing legacy `P2PRoom`, `SfuRoom`, `LocalP2PRoomMember`, and `LocalSFURoomMember` throughout the codebase (`src/conference/effects/room.ts`, `src/conference/stores/room.ts`, `src/conference/utils/skyway.ts`). [[1]](diffhunk://#diff-5fd08a4f03d0e13a9db4fbba50bfa72a826de7addf37c09b4e5db9e0e94fb3adL3-L11) [[2]](diffhunk://#diff-02ffa65b6c920aca0b32187a54702376fcade7d8aba7ee5a3a56728905dee179L4-R15) [[3]](diffhunk://#diff-aa62be5477bdceeafebb5656a634230cbbc9d440dc24026d0038875157a4aa30L2-R3)
* Corrected configuration property from `updateReminderSec` to `updateRemindSec` in config options.

**Room Initialization and Joining:**

* Updated room creation logic to use `type: "default"` instead of distinguishing between "sfu" and "p2p", and changed join methods to use the new member types. [[1]](diffhunk://#diff-aa62be5477bdceeafebb5656a634230cbbc9d440dc24026d0038875157a4aa30L55-R62) [[2]](diffhunk://#diff-aa62be5477bdceeafebb5656a634230cbbc9d440dc24026d0038875157a4aa30L2-R3)

**Media Publishing and Subscription Logic:**

* Refactored `publishAudio`, `publishVideo`, and `subscribe` functions to use the new API, passing room mode explicitly and updating encoding options based on whether the mode is "SFU" or "p2p". [[1]](diffhunk://#diff-5fd08a4f03d0e13a9db4fbba50bfa72a826de7addf37c09b4e5db9e0e94fb3adL299-R350) [[2]](diffhunk://#diff-5fd08a4f03d0e13a9db4fbba50bfa72a826de7addf37c09b4e5db9e0e94fb3adL45-R46) [[3]](diffhunk://#diff-5fd08a4f03d0e13a9db4fbba50bfa72a826de7addf37c09b4e5db9e0e94fb3adL98-R96) [[4]](diffhunk://#diff-5fd08a4f03d0e13a9db4fbba50bfa72a826de7addf37c09b4e5db9e0e94fb3adL166-R164) [[5]](diffhunk://#diff-5fd08a4f03d0e13a9db4fbba50bfa72a826de7addf37c09b4e5db9e0e94fb3adL194-R192)
